### PR TITLE
chore: rename LSFLK references to OpenGovMail after org transfer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@
 
 <!-- Explain how reviewers can test your changes. -->
 
-To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.
+To test the server, use the instructions in the [README](https://github.com/OpenGovMail/raven/blob/main/test/README.md) in the `test` directory.
 
 ---
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,8 +44,8 @@ jobs:
           target: raven-sasl
           push: true
           tags: |
-            ghcr.io/lsflk/raven-sasl:latest
-            ghcr.io/lsflk/raven-sasl:${{ steps.version.outputs.VERSION }}
+            ghcr.io/opengovmail/raven-sasl:latest
+            ghcr.io/opengovmail/raven-sasl:${{ steps.version.outputs.VERSION }}
 
       - name: Build and push raven-lmtp
         uses: docker/build-push-action@v5
@@ -55,8 +55,8 @@ jobs:
           target: raven-lmtp
           push: true
           tags: |
-            ghcr.io/lsflk/raven-lmtp:latest
-            ghcr.io/lsflk/raven-lmtp:${{ steps.version.outputs.VERSION }}
+            ghcr.io/opengovmail/raven-lmtp:latest
+            ghcr.io/opengovmail/raven-lmtp:${{ steps.version.outputs.VERSION }}
 
       - name: Build and push raven-imap
         uses: docker/build-push-action@v5
@@ -66,8 +66,8 @@ jobs:
           target: raven-imap
           push: true
           tags: |
-            ghcr.io/lsflk/raven-imap:latest
-            ghcr.io/lsflk/raven-imap:${{ steps.version.outputs.VERSION }}
+            ghcr.io/opengovmail/raven-imap:latest
+            ghcr.io/opengovmail/raven-imap:${{ steps.version.outputs.VERSION }}
 
       - name: Build and push raven-socketmap
         uses: docker/build-push-action@v5
@@ -77,8 +77,8 @@ jobs:
           target: raven-socketmap
           push: true
           tags: |
-            ghcr.io/lsflk/raven-socketmap:latest
-            ghcr.io/lsflk/raven-socketmap:${{ steps.version.outputs.VERSION }}
+            ghcr.io/opengovmail/raven-socketmap:latest
+            ghcr.io/opengovmail/raven-socketmap:${{ steps.version.outputs.VERSION }}
 
       - name: Build and push raven (combined)
         uses: docker/build-push-action@v5
@@ -88,5 +88,5 @@ jobs:
           target: raven
           push: true
           tags: |
-            ghcr.io/lsflk/raven:latest
-            ghcr.io/lsflk/raven:${{ steps.version.outputs.VERSION }}
+            ghcr.io/opengovmail/raven:latest
+            ghcr.io/opengovmail/raven:${{ steps.version.outputs.VERSION }}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This project adheres to a code of conduct that all contributors are expected to 
    ```
 3. **Add the upstream repository**:
    ```bash
-   git remote add upstream https://github.com/LSFLK/raven.git
+   git remote add upstream https://github.com/OpenGovMail/raven.git
    ```
 
 ## How to Contribute

--- a/docs/DELIVERY_SERVICE.md
+++ b/docs/DELIVERY_SERVICE.md
@@ -60,7 +60,7 @@ docker run -d --rm \
   -v $(pwd)/data:/app/data \
   -v $(pwd)/certs:/certs \
   -v $(pwd)/delivery.yaml:/app/delivery.yaml \
-  ghcr.io/lsflk/raven:latest
+  ghcr.io/opengovmail/raven:latest
 ```
 
 See the [example delivery.yaml](../config/delivery.yaml) for reference.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,9 @@
 **_A lightweight Mail Delivery Agent written in Go, providing IMAP, LMTP, and SASL support with SQLite-based storage._**
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-![CI](https://img.shields.io/github/actions/workflow/status/LSFLK/raven/release.yaml)
-![Security Scan](https://img.shields.io/github/actions/workflow/status/LSFLK/raven/linters.yaml?label=security)
-![Last Commit](https://img.shields.io/github/last-commit/LSFLK/raven)
+![CI](https://img.shields.io/github/actions/workflow/status/OpenGovMail/raven/release.yaml)
+![Security Scan](https://img.shields.io/github/actions/workflow/status/OpenGovMail/raven/linters.yaml?label=security)
+![Last Commit](https://img.shields.io/github/last-commit/OpenGovMail/raven)
 
 <p align="center">
   •   <a href="#why-raven">Why Raven?</a> •
@@ -62,21 +62,21 @@ All services use a **multi-database SQLite architecture** for efficient data iso
 ### Option 1: Pull from GitHub Container Registry (Recommended)
 
 ```bash
-docker pull ghcr.io/lsflk/raven:latest
+docker pull ghcr.io/opengovmail/raven:latest
 docker run -d --rm \
   --name raven \
   -p 143:143 -p 993:993 -p 24:24 \
   -v $(pwd)/config:/etc/raven \
   -v $(pwd)/data:/app/data \
   -v $(pwd)/certs:/certs \
-  ghcr.io/lsflk/raven:latest
+  ghcr.io/opengovmail/raven:latest
 ```
 
 ### Option 2: Build from Source
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/LSFLK/raven.git
+git clone https://github.com/OpenGovMail/raven.git
 cd raven
 ```
 
@@ -134,9 +134,9 @@ You can see the [example delivery.yaml](../config/delivery.yaml) for reference. 
 
 ## Contributing
 
-Thank you for wanting to contribute to our project. Please see [CONTRIBUTING.md](https://github.com/LSFLK/raven/blob/main/docs/CONTRIBUTING.md) for more details.
+Thank you for wanting to contribute to our project. Please see [CONTRIBUTING.md](https://github.com/OpenGovMail/raven/blob/main/docs/CONTRIBUTING.md) for more details.
 
 ## License
 
-Distributed under the Apache 2.0 License. See [LICENSE](https://github.com/LSFLK/raven/blob/main/LICENSE) for more information.
+Distributed under the Apache 2.0 License. See [LICENSE](https://github.com/OpenGovMail/raven/blob/main/LICENSE) for more information.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -23,4 +23,4 @@ If you discover a security vulnerability in this project, please report it by em
 
 We will respond within 48 hours to acknowledge receipt of your report. Once confirmed, we will work on a fix and notify you when the vulnerability is resolved.
 
-For urgent security issues, please use **PGP-encrypted email** with our [PGP public key](https://github.com/LSFLK/raven/blob/main/docs/keys/PGP_PUBLIC_KEY.asc).
+For urgent security issues, please use **PGP-encrypted email** with our [PGP public key](https://github.com/OpenGovMail/raven/blob/main/docs/keys/PGP_PUBLIC_KEY.asc).

--- a/internal/delivery/parser/parser_test.go
+++ b/internal/delivery/parser/parser_test.go
@@ -1495,7 +1495,7 @@ Content-Type: text/html; charset="UTF-8"
 <div dir=3D"ltr">Hi user,<div><img src=3D"cid:logo@example.com" alt=3D"Screens=
 hot 2026-01-04 at 11.33.43.png" width=3D"562" height=3D"556"><br></div></di=
 v><br><div class=3D"gmail_quote gmail_quote_container"><div dir=3D"ltr" cla=
-ss=3D"gmail_attr">On Tue, 20 Jan 2026 at 12:42, Aravinda H.W.K. &lt;<a href=
+ss=3D"gmail_attr">On Tue, 20 Jan 2026 at 12:42, User 1 &lt;<a href=
 =3D"mailto:user1@example.com">user1@example.com</a>&gt; wrote:<br><=
 /div><blockquote class=3D"gmail_quote" style=3D"margin:0px 0px 0px 0.8ex;bo=
 rder-left:1px solid rgb(204,204,204);padding-left:1ex">Hi user,<br>


### PR DESCRIPTION
## Description

Renames all `LSFLK` / `lsflk` references to `OpenGovMail` / `opengovmail` following the transfer of the repo to the `OpenGovMail` org. 22 references across 6 files.

**GitHub URLs / badges**
- `docs/README.md` — CI, Security Scan, and Last Commit shields.io badges; clone URL; CONTRIBUTING and LICENSE links
- `docs/CONTRIBUTING.md` — `git remote add upstream` URL
- `docs/SECURITY.md` — PGP public key link
- `.github/pull_request_template.md` — link to `test/README.md`

**GHCR image paths**
- `.github/workflows/release.yaml` — push targets for `raven-sasl`, `raven-lmtp`, `raven-imap`, `raven-socketmap`, and `raven`
- `docs/README.md`, `docs/DELIVERY_SERVICE.md` — `docker pull` / `docker run` examples

Closes #290

## Type of change

- [x] Chore / maintenance

## How to test

Docs changes are visual. For the workflow, confirm before merging that the `OpenGovMail` org grants the release workflow `packages: write` on GHCR, since `ghcr.io/opengovmail/*` is a new package namespace.

## Notes for reviewers

⚠️ **The GHCR change is user-facing.** After this merges, releases publish to `ghcr.io/opengovmail/*` instead of `ghcr.io/lsflk/*`. Anyone pulling `ghcr.io/lsflk/raven:latest` today will keep getting the old pinned image and silently stop receiving updates — GHCR does not redirect the way GitHub repo URLs do.

Two things worth deciding before merge:
1. Whether to **dual-publish** to both namespaces for a release or two as a deprecation window. I did not add this — say the word and I'll push it to this branch.
2. Announcing the image path change in the next release notes.

The doc/badge URL changes are safe either way — GitHub redirects `LSFLK/raven` → `OpenGovMail/raven`, so nothing was broken; this just makes them canonical.
