### PR TITLE
chore: rename silver references to OpenGovMail

### DIFF
--- a/.github/workflows/update-security-policy.yaml
+++ b/.github/workflows/update-security-policy.yaml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout default branch using Silver Bot token
+      - name: Checkout default branch using OpenGovMail Bot token
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
-          token: ${{ secrets.SILVER_BOT_TOKEN }}
+          token: ${{ secrets.OPENGOVMAIL_BOT_TOKEN }}
 
       - name: Update docs/SECURITY.md supported versions
         env:
@@ -77,14 +77,14 @@ jobs:
           security_md_path.write_text("\n".join(content) + "\n", encoding="utf-8")
           PY
 
-      - name: Create Pull Request as Silver Bot
+      - name: Create Pull Request as OpenGovMail Bot
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.SILVER_BOT_TOKEN }}
+          token: ${{ secrets.OPENGOVMAIL_BOT_TOKEN }}
           commit-message: "chore(security): update supported versions for ${{ github.event.release.tag_name }}"
-          committer: "${{ vars.SILVER_BOT_NAME }} <${{ vars.SILVER_BOT_EMAIL }}>"
-          author: "${{ vars.SILVER_BOT_NAME }} <${{ vars.SILVER_BOT_EMAIL }}>"
-          branch: silver-bot/update-security-${{ github.event.release.tag_name }}
+          committer: "${{ vars.OPENGOVMAIL_BOT_NAME }} <${{ vars.OPENGOVMAIL_BOT_EMAIL }}>"
+          author: "${{ vars.OPENGOVMAIL_BOT_NAME }} <${{ vars.OPENGOVMAIL_BOT_EMAIL }}>"
+          branch: opengovmail-bot/update-security-${{ github.event.release.tag_name }}
           base: ${{ github.event.repository.default_branch }}
           title: "chore(security): update supported versions for ${{ github.event.release.tag_name }}"
           body: |
@@ -92,6 +92,6 @@ jobs:
 
             Release: `${{ github.event.release.tag_name }}`
 
-            Generated automatically by Silver Bot.
+            Generated automatically by OpenGovMail Bot.
           add-paths: |
             docs/SECURITY.md

--- a/.github/workflows/welcome-outside-contributors.yaml
+++ b/.github/workflows/welcome-outside-contributors.yaml
@@ -25,7 +25,7 @@ jobs:
                   - name: Welcome first-time outside commenters on issues
                     uses: actions/github-script@v7
                     with:
-                          github-token: ${{ secrets.SILVER_BOT_TOKEN || github.token }}
+                          github-token: ${{ secrets.OPENGOVMAIL_BOT_TOKEN || github.token }}
                           script: |
                                 const issueNumber = context.payload.issue.number;
                                 const login = context.payload.comment.user.login;

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Raven (Silver Go IMAP)
+# Contributing to Raven (OpenGovMail Go IMAP)
 
-Thank you for your interest in contributing to the Raven (Silver Go IMAP) project! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to the Raven (OpenGovMail Go IMAP) project! This document provides guidelines and instructions for contributing.
 
 ## Table of Contents
 

--- a/internal/server/auth/authenticate_oauth_test.go
+++ b/internal/server/auth/authenticate_oauth_test.go
@@ -222,7 +222,7 @@ func TestAuthenticateOAuth_RejectsSASLUserEmailMismatch(t *testing.T) {
 		"aud":      []string{aud},
 		"exp":      time.Now().Add(2 * time.Minute).Unix(),
 		"username": "user2",
-		"email":    "user2@silver.example.com",
+		"email":    "user2@opengovmail.example.com",
 		"sub":      "subject-2",
 	})
 	if err != nil {

--- a/internal/server/auth/authenticateuser_test.go
+++ b/internal/server/auth/authenticateuser_test.go
@@ -243,7 +243,7 @@ func TestAuthenticateUser_SubdomainEmailFromIDP(t *testing.T) {
 	authServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"id":"user2@silver.example.com","type":"test-user","ouId":"silver"}`))
+		_, _ = w.Write([]byte(`{"id":"user2@opengovmail.example.com","type":"test-user","ouId":"opengovmail"}`))
 	}))
 	defer authServer.Close()
 
@@ -261,14 +261,14 @@ func TestAuthenticateUser_SubdomainEmailFromIDP(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user2@silver.example.com", "password"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user2@opengovmail.example.com", "password"}, state)
 
 	response := conn.GetWrittenData()
 	if !strings.Contains(response, "A001 OK") {
 		t.Fatalf("Expected successful login, got: %s", response)
 	}
 
-	if state.Email != "user2@silver.example.com" {
+	if state.Email != "user2@opengovmail.example.com" {
 		t.Fatalf("Expected canonical subdomain email, got: %s", state.Email)
 	}
 }
@@ -284,7 +284,7 @@ func TestAuthenticateUser_SubdomainEmailFromOrgUnitHierarchy(t *testing.T) {
 		case "/auth/credentials/authenticate":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"silveruser","ouId":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
+			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"opengovmailuser","ouId":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
 		case "/flow/execute":
 			var payload map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -333,7 +333,7 @@ func TestAuthenticateUser_SubdomainEmailFromOrgUnitHierarchy(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"019cf0a5-4109-79ac-857b-07fc7b5c19ac","handle":"silver","parent":"019cf0a3-c234-7190-a4c9-d5f6860a44e9"}`))
+			_, _ = w.Write([]byte(`{"id":"019cf0a5-4109-79ac-857b-07fc7b5c19ac","handle":"opengovmail","parent":"019cf0a3-c234-7190-a4c9-d5f6860a44e9"}`))
 		case "/organization-units/019cf0a3-c234-7190-a4c9-d5f6860a44e9":
 			if r.Header.Get("Authorization") != "Bearer test-assertion" {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -367,14 +367,14 @@ func TestAuthenticateUser_SubdomainEmailFromOrgUnitHierarchy(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user2@silver.example.com", "password"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user2@opengovmail.example.com", "password"}, state)
 
 	response := conn.GetWrittenData()
 	if !strings.Contains(response, "A001 OK") {
 		t.Fatalf("Expected successful login, got: %s", response)
 	}
 
-	if state.Email != "user2@silver.example.com" {
+	if state.Email != "user2@opengovmail.example.com" {
 		t.Fatalf("Expected OU-derived subdomain email, got: %s", state.Email)
 	}
 
@@ -394,7 +394,7 @@ func TestAuthenticateUser_UsernameWithDomainMismatchFromOrgUnit(t *testing.T) {
 		case "/auth/credentials/authenticate":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"silveruser","ouId":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
+			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"opengovmailuser","ouId":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
 		case "/flow/execute":
 			var payload map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -415,7 +415,7 @@ func TestAuthenticateUser_UsernameWithDomainMismatchFromOrgUnit(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"019cf0a5-4109-79ac-857b-07fc7b5c19ac","handle":"silver","parent":"019cf0a3-c234-7190-a4c9-d5f6860a44e9"}`))
+			_, _ = w.Write([]byte(`{"id":"019cf0a5-4109-79ac-857b-07fc7b5c19ac","handle":"opengovmail","parent":"019cf0a3-c234-7190-a4c9-d5f6860a44e9"}`))
 		case "/organization-units/019cf0a3-c234-7190-a4c9-d5f6860a44e9":
 			if r.Header.Get("Authorization") != "Bearer test-assertion" {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -463,7 +463,7 @@ func TestAuthenticateUser_UsernameWithDomainMatchesOrgUnit(t *testing.T) {
 		case "/auth/credentials/authenticate":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"silveruser","ouId":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
+			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"opengovmailuser","ouId":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
 		case "/flow/execute":
 			var payload map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -484,7 +484,7 @@ func TestAuthenticateUser_UsernameWithDomainMatchesOrgUnit(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"019cf0a5-4109-79ac-857b-07fc7b5c19ac","handle":"silver","parent":"019cf0a3-c234-7190-a4c9-d5f6860a44e9"}`))
+			_, _ = w.Write([]byte(`{"id":"019cf0a5-4109-79ac-857b-07fc7b5c19ac","handle":"opengovmail","parent":"019cf0a3-c234-7190-a4c9-d5f6860a44e9"}`))
 		case "/organization-units/019cf0a3-c234-7190-a4c9-d5f6860a44e9":
 			if r.Header.Get("Authorization") != "Bearer test-assertion" {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -513,7 +513,7 @@ func TestAuthenticateUser_UsernameWithDomainMatchesOrgUnit(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user2@silver.example.com", "password"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user2@opengovmail.example.com", "password"}, state)
 
 	response := conn.GetWrittenData()
 	if !strings.Contains(response, "A001 OK") {

--- a/internal/server/auth/helpers_internal_test.go
+++ b/internal/server/auth/helpers_internal_test.go
@@ -26,22 +26,22 @@ func TestResolveMailboxEmailPriority(t *testing.T) {
 			name:          "login email wins",
 			loginIdentity: " user@example.com ",
 			authID:        "id@example.net",
-			domain:        "silver.example.com",
+			domain:        "opengovmail.example.com",
 			want:          "user@example.com",
 		},
 		{
 			name:          "auth id email used",
 			loginIdentity: "user2",
-			authID:        "user2@silver.example.com",
+			authID:        "user2@opengovmail.example.com",
 			domain:        "example.com",
-			want:          "user2@silver.example.com",
+			want:          "user2@opengovmail.example.com",
 		},
 		{
 			name:          "derived domain fallback",
 			loginIdentity: "user2",
 			authID:        "019cf0a6-114a",
-			domain:        "silver.example.com",
-			want:          "user2@silver.example.com",
+			domain:        "opengovmail.example.com",
+			want:          "user2@opengovmail.example.com",
 		},
 		{
 			name:          "empty when nothing resolvable",
@@ -133,7 +133,7 @@ func TestResolveOrganizationUnitDomainAndCycle(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			switch r.URL.Path {
 			case "/organization-units/ou-child":
-				_, _ = w.Write([]byte(`{"id":"ou-child","handle":"silver","parent":"ou-root"}`))
+				_, _ = w.Write([]byte(`{"id":"ou-child","handle":"opengovmail","parent":"ou-root"}`))
 			case "/organization-units/ou-root":
 				_, _ = w.Write([]byte(`{"id":"ou-root","handle":"example.com","parent":null}`))
 			default:
@@ -146,8 +146,8 @@ func TestResolveOrganizationUnitDomainAndCycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("resolveOrganizationUnitDomain() unexpected error: %v", err)
 		}
-		if domain != "silver.example.com" {
-			t.Fatalf("domain = %q, want %q", domain, "silver.example.com")
+		if domain != "opengovmail.example.com" {
+			t.Fatalf("domain = %q, want %q", domain, "opengovmail.example.com")
 		}
 	})
 
@@ -275,7 +275,7 @@ func TestResolveDomainFromOrganizationUnit_AdditionalBranches(t *testing.T) {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"id":"ou-child","handle":"silver","parent":"ou-root"}`))
+			_, _ = w.Write([]byte(`{"id":"ou-child","handle":"opengovmail","parent":"ou-root"}`))
 		case "/organization-units/ou-root":
 			if r.Header.Get("Authorization") != "Bearer assertion-user" {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -298,8 +298,8 @@ func TestResolveDomainFromOrganizationUnit_AdditionalBranches(t *testing.T) {
 		t.Fatalf("extractBaseURL() = %q, want %q", baseURL, srv.URL)
 	}
 
-	if got := resolveDomainFromOrganizationUnit(srv.URL+"/auth/credentials/authenticate", "ou-child", "user2", "pass"); got != "silver.example.com" {
-		t.Fatalf("resolveDomainFromOrganizationUnit() = %q, want %q", got, "silver.example.com")
+	if got := resolveDomainFromOrganizationUnit(srv.URL+"/auth/credentials/authenticate", "ou-child", "user2", "pass"); got != "opengovmail.example.com" {
+		t.Fatalf("resolveDomainFromOrganizationUnit() = %q, want %q", got, "opengovmail.example.com")
 	}
 }
 


### PR DESCRIPTION
## Description

Renames the remaining 35 legacy `silver` / `Silver` / `SILVER` references to `opengovmail` / `OpenGovMail` / `OPENGOVMAIL` across 6 files.

**Docs**
- `docs/CONTRIBUTING.md` — `Raven (Silver Go IMAP)` → `Raven (OpenGovMail Go IMAP)` in the heading and intro

**Auth test fixtures**
- `internal/server/auth/authenticate_oauth_test.go`, `helpers_internal_test.go`, `authenticateuser_test.go` — fixture domain `silver.example.com` → `opengovmail.example.com`, OU handle `silver` → `opengovmail`, user type `silveruser` → `opengovmailuser`

**CI workflows**
- `.github/workflows/update-security-policy.yaml` — `secrets.SILVER_BOT_TOKEN` → `secrets.OPENGOVMAIL_BOT_TOKEN`, `vars.SILVER_BOT_NAME`/`EMAIL` → `vars.OPENGOVMAIL_BOT_NAME`/`EMAIL`, branch prefix `silver-bot/` → `opengovmail-bot/`, and the "Silver Bot" step names and PR body text
- `.github/workflows/welcome-outside-contributors.yaml` — `secrets.SILVER_BOT_TOKEN` → `secrets.OPENGOVMAIL_BOT_TOKEN`

Closes #292

## Type of change

- [x] Chore / maintenance

## How to test

`go test ./internal/server/auth/...` — passes locally (`ok raven/internal/server/auth 12.160s`). Several of these tests assert on the exact fixture strings, so a partial rename would have failed the run.

## ⚠️ Merge blocker — org secrets must exist first

This PR renames CI secret and variable references. **Those names are bound to entries in the org/repo settings, not to anything in this repo.** Before merging, confirm all three exist under `OpenGovMail` with the same values and permissions as the current `SILVER_BOT_*` entries:

- `OPENGOVMAIL_BOT_TOKEN` (secret)
- `OPENGOVMAIL_BOT_NAME` (variable)
- `OPENGOVMAIL_BOT_EMAIL` (variable)

If they are missing, GitHub resolves them to an **empty string** rather than failing the run, so the breakage is silent:

- `update-security-policy.yaml` would check out and open its release PR with an empty token — the automated security-policy job breaks on the next release.
- `welcome-outside-contributors.yaml` has a `|| github.token` fallback, so it would quietly stop commenting as the bot and use the default token instead.

Once a release cycle confirms both workflows still pass, the old `SILVER_BOT_*` secret and variables can be deleted.

## Notes for reviewers

- Depends on nothing in #291, but both touch `docs/CONTRIBUTING.md` on different lines (this PR line 1–3, #291 line 28), so they will not conflict.
- Worth a moment's thought on whether the bot account itself should stay the same identity under the OpenGovMail org, or be replaced with a new one as part of the transfer.
