### PR TITLE
fix: Reject CAPABILITY commands that include arguments

### DIFF
--- a/internal/server/auth/auth.go
+++ b/internal/server/auth/auth.go
@@ -67,7 +67,12 @@ func buildCapabilities(deps ServerDeps, isTLS bool) []string {
 	return capabilities
 }
 
-func HandleCapability(deps ServerDeps, conn net.Conn, tag string, state *models.ClientState) {
+func HandleCapability(deps ServerDeps, conn net.Conn, tag string, parts []string, state *models.ClientState) {
+	// RFC 3501: CAPABILITY takes no arguments.
+	if len(parts) > 2 {
+		deps.SendResponse(conn, fmt.Sprintf("%s BAD CAPABILITY takes no arguments", tag))
+		return
+	}
 	// Detect TLS: real TLS connection or test mock that advertises TLS
 	isTLS := false
 	if _, ok := conn.(*tls.Conn); ok {

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -52,7 +52,7 @@ func handleClient(s *IMAPServer, conn net.Conn, state *models.ClientState) {
 
 		switch cmd {
 		case "CAPABILITY":
-			auth.HandleCapability(s, conn, tag, state)
+			auth.HandleCapability(s, conn, tag, parts, state)
 		case "LOGIN":
 			auth.HandleLogin(s, conn, tag, parts, state)
 		case "AUTHENTICATE":

--- a/internal/server/testing_interface.go
+++ b/internal/server/testing_interface.go
@@ -26,7 +26,7 @@ func NewTestInterface(server *IMAPServer) *TestInterface {
 
 // HandleCapability exposes the capability handler for testing
 func (t *TestInterface) HandleCapability(conn net.Conn, tag string, state *models.ClientState) {
-	auth.HandleCapability(t.server, conn, tag, state)
+	auth.HandleCapability(t.server, conn, tag, []string{tag, "CAPABILITY"}, state)
 }
 
 // HandleLogin exposes the login handler for testing


### PR DESCRIPTION
## Summary

Reject CAPABILITY commands that include arguments

## Changes

- reject CAPABILITY commands that include arguments (RFC 3501 BAD)

Fixes #260
